### PR TITLE
Fix accidental removal of this.rotateButton

### DIFF
--- a/js/html_actuator.js
+++ b/js/html_actuator.js
@@ -47,6 +47,7 @@ HTMLActuator.prototype.continue = function () {
   }
 
   this.clearMessage();
+  this.rotateButton.textContent = "Rotate the board"
   this.gameContainer.classList.remove('rotate');
 };
 


### PR DESCRIPTION
Made a new branch but forgot to check it out before committing and pushing this fix! Noticed it in the master merge here: https://github.com/louh/2048-numberwang/commit/7416449f35cc3bdae076b47540523564fa880855
