### PR TITLE
Access Giphy API via HTTPS

### DIFF
--- a/js/html_actuator.js
+++ b/js/html_actuator.js
@@ -197,7 +197,7 @@ HTMLActuator.prototype.updateScore = function (score) {
         self = this.boardContainer;
 
     request.onload = loadGif;
-    request.open('GET', 'http://api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC', true);
+    request.open('GET', 'https://api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC', true);
     request.send(null);
 
     function loadGif () {


### PR DESCRIPTION
When playing 2048 Numberwang via HTTPS, Chrome refuses to load the random GIF image since the Giphy API is accessed via unencrypted HTTP and Chrome forbids HTTPS pages to perform XMLHttpRequests to HTTP endpoints. (Instead, the same image is used every time.) Since Giphy's API is accessible via HTTPS now, change the API URL to use it.