### PR TITLE
Replaced removed imgur link

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 
         <div class="tile-container"></div>
 
-        <div class="behind-board" style='background-image: url(http://i.imgur.com/6KZ4Vav.gif);'></div>
+        <div class="behind-board" style='background-image: url(https://i.imgur.com/Z5MQ8Uz.gif);'></div>
       </div>
     </div>
     <!--


### PR DESCRIPTION
The default gif behind the board no longer points to a valid url. I'm, not sure what it used to be but I've replaced it with a "let's rotate the board" gif. This gif only shows when a random gif from giphy can't be obtained (usually due to API rate limit exceeded).